### PR TITLE
chore: exclude Node.js artifacts from Deno operations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -52,5 +52,10 @@
   "test": {
     "include": ["tests/**/*.test.ts", "src/**/*.test.ts"],
     "exclude": ["tests/fixtures/**/*"]
-  }
+  },
+  "exclude": [
+    "node_modules/",
+    "package.json",
+    "package-lock.json"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `exclude` configuration to `deno.json` to ignore Node.js artifacts
- Excludes `node_modules/`, `package.json`, and `package-lock.json` from Deno operations

## Rationale
These files are only needed for semantic-release during CI/CD and should not be included in:
- Deno compilation (`deno compile`)
- Deno type checking and linting
- Other Deno runtime operations

## Test plan
- [x] Verify `deno.json` syntax is valid
- [ ] CI checks pass