### PR TITLE
fix: add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,11 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "semantic-release": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1047,6 +1051,19 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
       "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.0",
-    "@sebbo2002/semantic-release-jsr": "^2.0.0"
+    "@sebbo2002/semantic-release-jsr": "^2.0.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Fixes the semantic-release workflow failure by adding the missing `conventional-changelog-conventionalcommits` dependency.

## Problem
The release workflow was failing at the semantic-release step with:
```
Error: Cannot find module 'conventional-changelog-conventionalcommits'
```

## Root Cause
The `release.config.mjs` uses the `"conventionalcommits"` preset for both:
- `@semantic-release/commit-analyzer`
- `@semantic-release/release-notes-generator`

This preset requires the `conventional-changelog-conventionalcommits` package to be installed, but it was missing from `package.json`.

## Changes
- Added `conventional-changelog-conventionalcommits@^8.0.0` to devDependencies
- Updated package-lock.json

## Test Plan
- [x] Installed dependencies successfully with `npm install`
- [ ] Verify release workflow runs without module errors