### PR TITLE
feat: enable sticky comments for Claude code reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@90d189f3abd48655ec3e2c67c552cc23e92d6028 # ratchet:anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Enable the `use_sticky_comment` parameter in the Claude code review workflow to update the same comment on each PR synchronization instead of creating new review comments.

## Benefits

- Keeps PRs cleaner by avoiding multiple review comments
- Shows only the most recent review feedback
- Easier to track changes in review feedback across PR updates

## Changes

- Added `use_sticky_comment: true` to the Claude code review workflow configuration