### PR TITLE
fix(ci): use official Deno caching instead of manual actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,9 @@ jobs:
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # ratchet:denoland/setup-deno@v2
         with:
           deno-version: v2.x
-
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-            ~/.deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('deno.json', 'deno.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
+          cache: true
+          # setting `cache-hash` implies `cache: true` and replaces the default of `${{ hashFiles('**/deno.lock') }}`
+          cache-hash: ${{ hashFiles('**/deno.json', '**/deno.lock') }}
 
       - name: Run tests
         run: deno task test
@@ -48,16 +41,9 @@ jobs:
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # ratchet:denoland/setup-deno@v2
         with:
           deno-version: v2.x
-
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-            ~/.deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('deno.json', 'deno.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
+          cache: true
+          # setting `cache-hash` implies `cache: true` and replaces the default of `${{ hashFiles('**/deno.lock') }}`
+          cache-hash: ${{ hashFiles('**/deno.json', '**/deno.lock') }}
 
       - name: Check formatting
         run: deno fmt --check


### PR DESCRIPTION
## Summary

- Replaced manual `actions/cache@v4` steps with built-in `denoland/setup-deno` caching
- Added `cache: true` and custom `cache-hash` to both test and quality jobs
- Cache invalidates when `deno.json` or `deno.lock` changes

## Why This Change?

The previous manual caching approach had issues:
- Platform-specific cache paths not handled correctly (Linux/macOS/Windows differences)
- Deno's internal cache structure not properly managed
- Cache invalidation potentially incomplete

The official `denoland/setup-deno` caching:
- Handles platform-specific paths automatically
- Properly manages Deno's internal directory structure
- Uses official cache invalidation logic

## References

- [Deno CI Documentation](https://docs.deno.com/runtime/reference/continuous_integration/)
- [denoland/setup-deno](https://github.com/denoland/setup-deno)