### PR TITLE
fix(ci): use official Deno caching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,9 @@ jobs:
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # ratchet:denoland/setup-deno@v2
         with:
           deno-version: v2.x
-
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-            ~/.deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('deno.json', 'deno.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
+          cache: true
+          # setting `cache-hash` implies `cache: true` and replaces the default of `${{ hashFiles('**/deno.lock') }}`
+          cache-hash: ${{ hashFiles('**/deno.json', '**/deno.lock') }}
 
       - name: Validate code
         run: |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Claude Cleaner
 
-[![CI](https://github.com/tylerbu/claude-cleaner/actions/workflows/ci.yml/badge.svg)](https://github.com/tylerbu/claude-cleaner/actions/workflows/ci.yml)
+[![CI](https://github.com/tylerbutler/claude-cleaner/actions/workflows/ci.yml/badge.svg)](https://github.com/tylerbutler/claude-cleaner/actions/workflows/ci.yml)
 [![JSR](https://jsr.io/badges/@tylerbu/claude-cleaner)](https://jsr.io/@tylerbu/claude-cleaner)
 [![JSR Score](https://jsr.io/badges/@tylerbu/claude-cleaner/score)](https://jsr.io/@tylerbu/claude-cleaner)
-[![GitHub release](https://img.shields.io/github/v/release/tylerbu/claude-cleaner)](https://github.com/tylerbu/claude-cleaner/releases/latest)
-[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey)](https://github.com/tylerbu/claude-cleaner/releases)
+[![GitHub release](https://img.shields.io/github/v/release/tylerbutler/claude-cleaner)](https://github.com/tylerbutler/claude-cleaner/releases/latest)
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey)](https://github.com/tylerbutler/claude-cleaner/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 A TypeScript/Deno tool to remove Claude artifacts from Git repositories.


### PR DESCRIPTION
## Summary
- Update release.yml to use `denoland/setup-deno`'s built-in caching instead of manual `actions/cache`
- Fix badge URLs from `tylerbu/` to `tylerbutler/` in README.md

## Changes
- Removed manual `actions/cache@v4` step from release workflow
- Added `cache: true` and `cache-hash` parameters to `denoland/setup-deno` action
- Updated GitHub badge URLs to use correct repository owner (`tylerbutler`)

## Test plan
- CI workflow should pass with proper Deno caching
- Badges should display correctly with updated URLs