### PR TITLE
fix(release): prevent breaking changes from bumping to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠ BREAKING CHANGES
 
-* **cli:** Repository path is now a required positional argument instead of an optional --repo-path flag.
+- **cli:** Repository path is now a required positional argument instead of an optional --repo-path flag.
 
 Before (v0.1.x):
-  claude-cleaner --files-only                        # defaulted to current directory
-  claude-cleaner --repo-path /path/to/repo --execute
+claude-cleaner --files-only # defaulted to current directory
+claude-cleaner --repo-path /path/to/repo --execute
 
 After (v0.2.0):
-  claude-cleaner . --files-only                      # explicit path required
-  claude-cleaner /path/to/repo --execute
+claude-cleaner . --files-only # explicit path required
+claude-cleaner /path/to/repo --execute
 
 Changes:
+
 - Remove --repo-path option flag
 - Add required positional <repo-path> argument
 - Update all tests to use isolated test repositories
@@ -29,15 +30,18 @@ Changes:
 - Bump version to 0.2.0
 
 Test Changes:
+
 - Create test repository helpers in cli-options.test.ts
 - All tests now use temporary test repos instead of operating on real repo
 - All 52 tests pass (221 test steps)
 
 Cleanup:
+
 - Delete backup branches created by test corruption
 - Fix error message referencing old --repo-path flag
 
 Other:
+
 - Add comprehensive ErrorCode type union with all error codes
 - Consolidate NOT_GIT_REPOSITORY to NOT_GIT_REPO
 - Delete HANDOFF.md development artifact
@@ -45,34 +49,34 @@ Other:
 
 ### ✨ Features
 
-* enable sticky comments for Claude code reviews ([#12](https://github.com/tylerbutler/claude-cleaner/issues/12)) ([8813394](https://github.com/tylerbutler/claude-cleaner/commit/881339465021cb86870e42a75b4d096ec87094d1))
-* re-enable Windows tests to diagnose CI failures ([#18](https://github.com/tylerbutler/claude-cleaner/issues/18)) ([d99a41b](https://github.com/tylerbutler/claude-cleaner/commit/d99a41bf80827988723d05daa6c9f9af8943e2c9))
+- enable sticky comments for Claude code reviews ([#12](https://github.com/tylerbutler/claude-cleaner/issues/12)) ([8813394](https://github.com/tylerbutler/claude-cleaner/commit/881339465021cb86870e42a75b4d096ec87094d1))
+- re-enable Windows tests to diagnose CI failures ([#18](https://github.com/tylerbutler/claude-cleaner/issues/18)) ([d99a41b](https://github.com/tylerbutler/claude-cleaner/commit/d99a41bf80827988723d05daa6c9f9af8943e2c9))
 
 ### 🐛 Bug Fixes
 
-* add missing conventional-changelog-conventionalcommits dependency ([#11](https://github.com/tylerbutler/claude-cleaner/issues/11)) ([b4422f9](https://github.com/tylerbutler/claude-cleaner/commit/b4422f9c6a0fc8739a816d18cdb7510aaffebd08))
-* **cli:** require repository path as positional argument ([#3](https://github.com/tylerbutler/claude-cleaner/issues/3)) ([a27a486](https://github.com/tylerbutler/claude-cleaner/commit/a27a486aa3c4602b56cafca1657a70c57a081c1b))
-* **ci:** use official Deno caching in release workflow ([#21](https://github.com/tylerbutler/claude-cleaner/issues/21)) ([ed25572](https://github.com/tylerbutler/claude-cleaner/commit/ed255727d92e72350d1a06587ecf60de25f3a445))
-* **ci:** use official Deno caching instead of manual actions/cache ([#19](https://github.com/tylerbutler/claude-cleaner/issues/19)) ([a144be6](https://github.com/tylerbutler/claude-cleaner/commit/a144be6b36ad42abe796e6a1c571dc7ecf537017))
+- add missing conventional-changelog-conventionalcommits dependency ([#11](https://github.com/tylerbutler/claude-cleaner/issues/11)) ([b4422f9](https://github.com/tylerbutler/claude-cleaner/commit/b4422f9c6a0fc8739a816d18cdb7510aaffebd08))
+- **cli:** require repository path as positional argument ([#3](https://github.com/tylerbutler/claude-cleaner/issues/3)) ([a27a486](https://github.com/tylerbutler/claude-cleaner/commit/a27a486aa3c4602b56cafca1657a70c57a081c1b))
+- **ci:** use official Deno caching in release workflow ([#21](https://github.com/tylerbutler/claude-cleaner/issues/21)) ([ed25572](https://github.com/tylerbutler/claude-cleaner/commit/ed255727d92e72350d1a06587ecf60de25f3a445))
+- **ci:** use official Deno caching instead of manual actions/cache ([#19](https://github.com/tylerbutler/claude-cleaner/issues/19)) ([a144be6](https://github.com/tylerbutler/claude-cleaner/commit/a144be6b36ad42abe796e6a1c571dc7ecf537017))
 
 ### ⚡ Performance Improvements
 
-* batch BFG operations into single pass ([#13](https://github.com/tylerbutler/claude-cleaner/issues/13)) ([a7747c7](https://github.com/tylerbutler/claude-cleaner/commit/a7747c705e88540fdf660559786e040a2fb32b21))
+- batch BFG operations into single pass ([#13](https://github.com/tylerbutler/claude-cleaner/issues/13)) ([a7747c7](https://github.com/tylerbutler/claude-cleaner/commit/a7747c705e88540fdf660559786e040a2fb32b21))
 
 ### 📝 Documentation
 
-* Add jsr installation info ([21e8fc1](https://github.com/tylerbutler/claude-cleaner/commit/21e8fc1075378d44ec8e4840a31e6f02eeab77da))
-* improve pattern matching and basename logic clarity ([#9](https://github.com/tylerbutler/claude-cleaner/issues/9)) ([e9f05e5](https://github.com/tylerbutler/claude-cleaner/commit/e9f05e5d3b577d053ab9f66e1901725b24c88c45))
+- Add jsr installation info ([21e8fc1](https://github.com/tylerbutler/claude-cleaner/commit/21e8fc1075378d44ec8e4840a31e6f02eeab77da))
+- improve pattern matching and basename logic clarity ([#9](https://github.com/tylerbutler/claude-cleaner/issues/9)) ([e9f05e5](https://github.com/tylerbutler/claude-cleaner/commit/e9f05e5d3b577d053ab9f66e1901725b24c88c45))
 
 ### ♻️ Code Refactoring
 
-* hybrid glob/regex pattern matching ([#2](https://github.com/tylerbutler/claude-cleaner/issues/2)) ([a826f09](https://github.com/tylerbutler/claude-cleaner/commit/a826f093ce9f05d66794d9f0e19ac0d8e231c391))
+- hybrid glob/regex pattern matching ([#2](https://github.com/tylerbutler/claude-cleaner/issues/2)) ([a826f09](https://github.com/tylerbutler/claude-cleaner/commit/a826f093ce9f05d66794d9f0e19ac0d8e231c391))
 
 ### 👷 CI/CD
 
-* add Deno caching and enhance release configuration ([#6](https://github.com/tylerbutler/claude-cleaner/issues/6)) ([c1ada5c](https://github.com/tylerbutler/claude-cleaner/commit/c1ada5c5e36e1dfabdf1eff6eea4bb5e5e4e2792))
-* implement semantic-release for automated versioning ([#5](https://github.com/tylerbutler/claude-cleaner/issues/5)) ([ac1abf8](https://github.com/tylerbutler/claude-cleaner/commit/ac1abf8e30b5e23b945f395fddad66f9665c7738))
-* pin GitHub Actions to commit SHAs with ratchet ([#8](https://github.com/tylerbutler/claude-cleaner/issues/8)) ([b8cf9b4](https://github.com/tylerbutler/claude-cleaner/commit/b8cf9b4f4f3e8c7719ef5b4c6614919a15b662f1))
+- add Deno caching and enhance release configuration ([#6](https://github.com/tylerbutler/claude-cleaner/issues/6)) ([c1ada5c](https://github.com/tylerbutler/claude-cleaner/commit/c1ada5c5e36e1dfabdf1eff6eea4bb5e5e4e2792))
+- implement semantic-release for automated versioning ([#5](https://github.com/tylerbutler/claude-cleaner/issues/5)) ([ac1abf8](https://github.com/tylerbutler/claude-cleaner/commit/ac1abf8e30b5e23b945f395fddad66f9665c7738))
+- pin GitHub Actions to commit SHAs with ratchet ([#8](https://github.com/tylerbutler/claude-cleaner/issues/8)) ([b8cf9b4](https://github.com/tylerbutler/claude-cleaner/commit/b8cf9b4f4f3e8c7719ef5b4c6614919a15b662f1))
 
 # Changelog
 

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -19,8 +19,10 @@ export default {
           { type: "build", release: false },
           { type: "ci", release: false },
           { type: "chore", release: false },
-          // Breaking changes always trigger major release regardless of type
-          { breaking: true, release: "major" },
+          // Breaking changes bump minor version in pre-1.0 (0.x.x)
+          // This prevents 0.x.x → 1.0.0 until we're ready for stable release
+          // Change to "major" when ready for 1.0.0+
+          { breaking: true, release: "minor" },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
Configure semantic-release to keep versions at 0.x.x during pre-1.0 development phase.

## Changes
- Updated `release.config.mjs` to bump **minor** version instead of **major** for breaking changes
- Breaking changes will now: `0.1.0 → 0.2.0` (not `0.1.0 → 1.0.0`)
- Added comments explaining the configuration and how to revert when ready for 1.0.0

## Rationale
Following semantic versioning best practices for pre-1.0 software:
- Allows us to ship breaking changes while signaling API instability
- Prevents premature bump to 1.0.0 before we're ready
- Easy to switch back to standard semver by changing one line

## References
- [Semantic Versioning 2.0.0 - Major version zero](https://semver.org/#spec-item-4)
- [semantic-release Issue #1507](https://github.com/semantic-release/semantic-release/issues/1507)
- Community solutions for 0.x versioning with semantic-release

## Testing
When ready for 1.0.0, change line 25 back to:
\`\`\`javascript
{ breaking: true, release: "major" }
\`\`\`